### PR TITLE
Add Telegram and Facebook interaction stubs

### DIFF
--- a/agents/facebook/interactive.py
+++ b/agents/facebook/interactive.py
@@ -1,0 +1,43 @@
+import asyncio
+import requests
+from typing import Dict
+
+from common.utils.logging import setup_logger
+
+logger = setup_logger(__name__)
+
+async def post_to_page(page_id: str, message: str, access_token: str) -> Dict[str, str]:
+    """Post a text update to a Facebook Page."""
+    url = f"https://graph.facebook.com/{page_id}/feed"
+    payload = {"message": message, "access_token": access_token}
+    loop = asyncio.get_running_loop()
+    try:
+        response = await loop.run_in_executor(None, lambda: requests.post(url, data=payload, timeout=10))
+        data = response.json()
+        if data.get("id"):
+            return {"status": True, "post_id": data["id"]}
+        logger.error(f"Facebook API error: {data}")
+        return {"status": False, "message": str(data)}
+    except Exception as e:
+        logger.error(f"Failed to post to page: {e}")
+        return {"status": False, "message": str(e)}
+
+async def send_message(recipient_id: str, message: str, access_token: str) -> Dict[str, str]:
+    """Send a direct message from a Page."""
+    url = "https://graph.facebook.com/v17.0/me/messages"
+    payload = {
+        "recipient": f"{{\"id\":\"{recipient_id}\"}}",
+        "message": f"{{\"text\":\"{message}\"}}",
+        "access_token": access_token
+    }
+    loop = asyncio.get_running_loop()
+    try:
+        response = await loop.run_in_executor(None, lambda: requests.post(url, data=payload, timeout=10))
+        data = response.json()
+        if data.get("recipient_id"):
+            return {"status": True, "recipient_id": data.get("recipient_id"), "message_id": data.get("message_id")}
+        logger.error(f"Facebook API error: {data}")
+        return {"status": False, "message": str(data)}
+    except Exception as e:
+        logger.error(f"Failed to send message: {e}")
+        return {"status": False, "message": str(e)}

--- a/agents/telegram/interactive.py
+++ b/agents/telegram/interactive.py
@@ -1,0 +1,39 @@
+import asyncio
+import requests
+from typing import Dict
+
+from common.utils.logging import setup_logger
+
+logger = setup_logger(__name__)
+
+async def send_message(chat_id: str, text: str, token: str) -> Dict[str, str]:
+    """Send a text message via the Telegram Bot API."""
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = {"chat_id": chat_id, "text": text}
+    loop = asyncio.get_running_loop()
+    try:
+        response = await loop.run_in_executor(None, lambda: requests.post(url, data=payload, timeout=10))
+        data = response.json()
+        if data.get("ok"):
+            return {"status": True, "message_id": data["result"]["message_id"]}
+        logger.error(f"Telegram API error: {data}")
+        return {"status": False, "message": data.get("description", "error")}
+    except Exception as e:
+        logger.error(f"Failed to send message: {e}")
+        return {"status": False, "message": str(e)}
+
+async def send_photo(chat_id: str, photo_url: str, caption: str, token: str) -> Dict[str, str]:
+    """Send a photo with optional caption via the Telegram Bot API."""
+    url = f"https://api.telegram.org/bot{token}/sendPhoto"
+    payload = {"chat_id": chat_id, "photo": photo_url, "caption": caption}
+    loop = asyncio.get_running_loop()
+    try:
+        response = await loop.run_in_executor(None, lambda: requests.post(url, data=payload, timeout=10))
+        data = response.json()
+        if data.get("ok"):
+            return {"status": True, "message_id": data["result"]["message_id"]}
+        logger.error(f"Telegram API error: {data}")
+        return {"status": False, "message": data.get("description", "error")}
+    except Exception as e:
+        logger.error(f"Failed to send photo: {e}")
+        return {"status": False, "message": str(e)}

--- a/agents_registry.json
+++ b/agents_registry.json
@@ -1758,6 +1758,136 @@
           }
         }
       ]
+    },
+    "telegram": {
+      "interactive": [
+        {
+          "agent_id": "telegram_interactive",
+          "function_id": "send_message",
+          "description": "Send a text message using the Telegram Bot API",
+          "parameters": [
+            {
+              "name": "chat_id",
+              "type": "str",
+              "description": "Target chat ID",
+              "required": true
+            },
+            {
+              "name": "text",
+              "type": "str",
+              "description": "Message text",
+              "required": true
+            },
+            {
+              "name": "token",
+              "type": "str",
+              "description": "Telegram bot token",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "Dict[str, str]",
+            "description": "Result of the send operation including status and message ID"
+          }
+        },
+        {
+          "agent_id": "telegram_interactive",
+          "function_id": "send_photo",
+          "description": "Send a photo with optional caption via Telegram",
+          "parameters": [
+            {
+              "name": "chat_id",
+              "type": "str",
+              "description": "Target chat ID",
+              "required": true
+            },
+            {
+              "name": "photo_url",
+              "type": "str",
+              "description": "URL of the photo",
+              "required": true
+            },
+            {
+              "name": "caption",
+              "type": "str",
+              "description": "Photo caption",
+              "required": true
+            },
+            {
+              "name": "token",
+              "type": "str",
+              "description": "Telegram bot token",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "Dict[str, str]",
+            "description": "Result of the send operation including status and message ID"
+          }
+        }
+      ]
+    },
+    "facebook": {
+      "interactive": [
+        {
+          "agent_id": "facebook_interactive",
+          "function_id": "post_to_page",
+          "description": "Post a text update to a Facebook page",
+          "parameters": [
+            {
+              "name": "page_id",
+              "type": "str",
+              "description": "Target page ID",
+              "required": true
+            },
+            {
+              "name": "message",
+              "type": "str",
+              "description": "Text content to publish",
+              "required": true
+            },
+            {
+              "name": "access_token",
+              "type": "str",
+              "description": "Facebook page access token",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "Dict[str, str]",
+            "description": "Result of the post operation including status and post ID"
+          }
+        },
+        {
+          "agent_id": "facebook_interactive",
+          "function_id": "send_message",
+          "description": "Send a direct message from a Facebook page",
+          "parameters": [
+            {
+              "name": "recipient_id",
+              "type": "str",
+              "description": "ID of the recipient user",
+              "required": true
+            },
+            {
+              "name": "message",
+              "type": "str",
+              "description": "Message text",
+              "required": true
+            },
+            {
+              "name": "access_token",
+              "type": "str",
+              "description": "Facebook page access token",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "Dict[str, str]",
+            "description": "Result of the send operation including status and message ID"
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add simple Telegram interactive functions for sending messages and photos
- implement Facebook interactive helpers to post updates or messages
- register the new Telegram and Facebook functions in the agent registry

## Testing
- `python -m py_compile agents/telegram/interactive.py agents/facebook/interactive.py`
- `python3 -m json.tool agents_registry.json`
- `pip install pydantic==2.11.2` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68585f57564c83338a29555fd04e2771